### PR TITLE
Updated web.config to fix sign in Url issue

### DIFF
--- a/Website/Web.config
+++ b/Website/Web.config
@@ -5,6 +5,7 @@
     <add key="blog:theme" value="barebone"/>
     <add key="blog:name" value="MiniBlog"/>
     <add key="blog:postsPerPage" value="5"/>
+    <add key="PreserveLoginUrl" value="true" />
   </appSettings>
 
   <system.web>


### PR DESCRIPTION
Clicking the Sign In link was redirecting to "Account/Login" which did
not exist, and resulted in a 404 error. Added an appSetting to ensure
the configured LoginUrl value for FormsAuth is used.
