### PR TITLE
Add option for Blog.GetPosts() to retrieve all posts; fix paging

### DIFF
--- a/Website/app_code/code/Blog.cs
+++ b/Website/app_code/code/Blog.cs
@@ -77,7 +77,7 @@ public static class Blog
         }
     }
 
-    public static IEnumerable<Post> GetPosts(int postsPerPage)
+    public static IEnumerable<Post> GetPosts(int postsPerPage = 0)
     {
         var posts = from p in Storage.GetAllPosts()
                     where (p.IsPublished && p.PubDate <= DateTime.UtcNow) || HttpContext.Current.User.Identity.IsAuthenticated
@@ -90,7 +90,12 @@ public static class Blog
             posts = posts.Where(p => p.Categories.Any(c => string.Equals(c, category, StringComparison.OrdinalIgnoreCase)));
         }
 
-        return posts.Skip(postsPerPage * (CurrentPage - 1)).Take(postsPerPage);
+        if (postsPerPage > 0)
+        {
+            posts = posts.Skip(postsPerPage * (CurrentPage - 1)).Take(postsPerPage);
+        }
+
+        return posts;
     }
 
     public static string SaveFileToDisk(byte[] bytes, string extension)

--- a/Website/themes/OffCanvas/_Layout.cshtml
+++ b/Website/themes/OffCanvas/_Layout.cshtml
@@ -39,7 +39,7 @@
                 @if (Page.ShowPaging != null)
                 {
                     <ul class="pager">
-                        @if (Blog.GetPosts(Blog.PostsPerPage * 2).Count() > Blog.PostsPerPage)
+                        @if (Blog.GetPosts().Count() > Blog.PostsPerPage * Blog.CurrentPage)
                         {
                             <li class="previous"><a href="@Blog.GetPagingUrl(1)" rel="prev">&larr; Older</a></li>
                         }

--- a/Website/themes/OneColumn/_Layout.cshtml
+++ b/Website/themes/OneColumn/_Layout.cshtml
@@ -38,7 +38,7 @@
             @if (Page.ShowPaging != null)
             {
                 <ul class="pager">
-                    @if (Blog.GetPosts(Blog.PostsPerPage * 2).Count() > Blog.PostsPerPage)
+                    @if (Blog.GetPosts().Count() > Blog.PostsPerPage * Blog.CurrentPage)
                     {
                         <li class="previous"><a href="@Blog.GetPagingUrl(1)" rel="prev">&larr; Older</a></li>
                     }

--- a/Website/themes/TwoColumns/_Layout.cshtml
+++ b/Website/themes/TwoColumns/_Layout.cshtml
@@ -38,7 +38,7 @@
             @if (Page.ShowPaging != null)
             {
                 <ul class="pager">
-                    @if (Blog.GetPosts(Blog.PostsPerPage * 2).Count() > Blog.PostsPerPage)
+                    @if (Blog.GetPosts().Count() > Blog.PostsPerPage * Blog.CurrentPage)
                     {
                         <li class="previous"><a href="@Blog.GetPagingUrl(1)" rel="prev">&larr; Older</a></li>
                     }


### PR DESCRIPTION
Currently there is a bug where the "Older" link does not display when there are more pages. In order for paging logic to function properly, it needs the total number of all posts (or all posts in category). 

Modified the postsPerPage parameter in Blog.GetPosts() to be optional and return all posts if not supplied. Updated the pagers on sample themes hide/show the Older link correctly.

Thanks!
