### PR TITLE
Remove async attribute from script tags

### DIFF
--- a/Website/views/AdminMenu.cshtml
+++ b/Website/views/AdminMenu.cshtml
@@ -73,6 +73,6 @@
 @if (!string.IsNullOrEmpty(Blog.CurrentSlug))
 {
     <script src="@Blog.FingerPrint("/scripts/jquery-2.0.2.js", "//ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js")"></script>
-    <script src="@Blog.FingerPrint("/scripts/bootstrap-wysiwyg.js")" async defer></script>
-    <script src="@Blog.FingerPrint("/scripts/admin.js")" async defer></script>
+    <script src="@Blog.FingerPrint("/scripts/bootstrap-wysiwyg.js")" defer></script>
+    <script src="@Blog.FingerPrint("/scripts/admin.js")" defer></script>
 }


### PR DESCRIPTION
Remove async attribute from script tags that are/have dependencies so that wysiwyg editor will work when creating or editing a post in the browser.
