### PR TITLE
Swapped glyphicon-lock (which is broken) for glyphicon-log-in and glyphi...

### DIFF
--- a/Website/themes/OffCanvas/_Layout.cshtml
+++ b/Website/themes/OffCanvas/_Layout.cshtml
@@ -89,7 +89,7 @@
         @if (!User.Identity.IsAuthenticated)
         {
             <span class="pull-right">
-                <a href="@FormsAuthentication.LoginUrl?ReturnUrl=@Request.RawUrl">Sign in <i class="glyphicon glyphicon-lock"></i></a>
+                <a href="@FormsAuthentication.LoginUrl?ReturnUrl=@Request.RawUrl">Sign in <i class="glyphicon glyphicon-log-in"></i></a>
             </span>
         }
         <span>

--- a/Website/themes/OneColumn/_Layout.cshtml
+++ b/Website/themes/OneColumn/_Layout.cshtml
@@ -69,7 +69,7 @@
         @if (!User.Identity.IsAuthenticated)
         {
             <span class="pull-right">
-                <a href="@FormsAuthentication.LoginUrl?ReturnUrl=@Request.RawUrl">Sign in <i class="glyphicon glyphicon-lock"></i></a>
+                <a href="@FormsAuthentication.LoginUrl?ReturnUrl=@Request.RawUrl">Sign in <i class="glyphicon glyphicon-log-in"></i></a>
             </span>
         }
         <span>

--- a/Website/themes/TwoColumns/_Layout.cshtml
+++ b/Website/themes/TwoColumns/_Layout.cshtml
@@ -87,7 +87,7 @@
         @if (!User.Identity.IsAuthenticated)
         {
             <span class="pull-right">
-                <a href="@FormsAuthentication.LoginUrl?ReturnUrl=@Request.RawUrl">Sign in <i class="glyphicon glyphicon-lock"></i></a>
+                <a href="@FormsAuthentication.LoginUrl?ReturnUrl=@Request.RawUrl">Sign in <i class="glyphicon glyphicon-log-in"></i></a>
             </span>
         }
         <span>

--- a/Website/views/AdminMenu.cshtml
+++ b/Website/views/AdminMenu.cshtml
@@ -61,7 +61,7 @@
 
     <form action="@FormsAuthentication.LoginUrl?signout=true&amp;ReturnUrl=@Request.RawUrl" method="post">
         <button type="submit" title="Signed in as @User.Identity.Name" class="btn btn-link pull-right">
-            Sign out &nbsp;<span class="glyphicon glyphicon-lock"></span>
+            Sign out &nbsp;<span class="glyphicon glyphicon-log-out"></span>
         </button>
     </form>
 


### PR DESCRIPTION
I was tired of seeing that little broken glyphicon lock so I swapped it out for another of the glyphicons--actually two others: glyphicon-log-in and glyphicon-log-out.

As for the reason the glyphicon-lock isn't appearing correctly, I didn't nail down the reason entirely, but it seems that the CDN's copy of the CSS or the copy of the font file isn't quite up to snuff. This works around that issue in a way that I think is probably better anyway, glyphicon problem or no.
