### PR TITLE
Fixed comment.ashx 404 when in virtual directory

### DIFF
--- a/Website/scripts/comments.js
+++ b/Website/scripts/comments.js
@@ -214,6 +214,7 @@
 
     function initialize() {
         postId = document.querySelector("[itemprop=blogPost]").getAttribute("data-id");
+        endpoint = document.getElementById("commentform").getAttribute("data-blog-path") + endpoint;
         var email = document.getElementById("commentemail");
         var name = document.getElementById("commentname");
         var website = document.getElementById("commenturl");

--- a/Website/views/CommentForm.cshtml
+++ b/Website/views/CommentForm.cshtml
@@ -1,4 +1,7 @@
-﻿<form id="commentform" role="form" class="form-horizontal">
+﻿@{
+    var path = !string.IsNullOrWhiteSpace(Blog.BlogPath) ? "/" + Blog.BlogPath : "";
+}
+<form id="commentform" role="form" class="form-horizontal" data-blog-path="@path">
     <fieldset>
         <legend>Post comment</legend>
 		


### PR DESCRIPTION
Added `blogPath` in the commenting functionality so calls to the `comment.ashx` doesn't 404 when in an virtual directory. At the moment it's broken.

Although now this `var path = !string.IsNullOrWhiteSpace(Blog.BlogPath) ? "/" + Blog.BlogPath : "";` exists in both `CommentForm.cshtml` and `AdminMenu.cshtml`.
This code probably is unecessary anyway if the slash is already added in `blog:path` and Razor should handle null values, due to missing the element, without problems.

I made some changes regarding the above and to enable `data-blog-path` sharing between the script-files in this fredrikeriksson@ef8004dd708b8d79a31895b823fe7357e6346355 branch.
If the changes seems alright I'll merge them to this branch, if not, take this as is
