### PR TITLE
AJAX requests now skips customError behavior

### DIFF
--- a/Website/Global.asax
+++ b/Website/Global.asax
@@ -26,5 +26,22 @@
             application.Context.Response.Headers.Remove("Server");
         }
     }
+
+    public void Application_OnError()
+    {
+        var request = HttpContext.Current.Request;
+        var exception = Server.GetLastError() as HttpException;
+        if (exception == null) return;
+        
+        //Prevents customError behavior when the request is determined to be an AJAX request.
+        if (request["X-Requested-With"] == "XMLHttpRequest" || request.Headers["X-Requested-With"] == "XMLHttpRequest")
+        {
+            Server.ClearError();
+            Response.ClearContent();
+            Response.StatusCode = exception.GetHttpCode();
+            Response.StatusDescription = exception.Message;
+            Response.Write(string.Format("<html><body><h1>{0} {1}</h1></body></html>", exception.GetHttpCode(), exception.Message));
+        }
+    }
        
 </script>


### PR DESCRIPTION
Added code i Global.asax to prevent redirects to ~/ or ~/404.cshtml
when the request is considered an AJAX request.
This is to prevent redirections of the requests which results in a
valid page and status code 200 and not the status code from thrown
HttpException which results in that the success/fail functionality
always thinks it's a success, even when it's not.

Fixes #104
