### PR TITLE
Modify PostHandler.CreateSlug to allow non-ascii character

### DIFF
--- a/Website/app_code/handlers/PostHandler.cs
+++ b/Website/app_code/handlers/PostHandler.cs
@@ -88,9 +88,8 @@ public class PostHandler : IHttpHandler
     {
         title = title.ToLowerInvariant().Replace(" ", "-");
         title = RemoveDiacritics(title);
-        title = Regex.Replace(title, @"([^0-9a-z-])", string.Empty);
 
-        if (Storage.GetAllPosts().Any(p => string.Equals(p.Slug, title)))
+        if (Storage.GetAllPosts().Any(p => string.Equals(p.Slug, title, StringComparison.OrdinalIgnoreCase)))
             throw new HttpException(409, "Already in use");
 
         return title.ToLowerInvariant();


### PR DESCRIPTION
when i give a title with non-ascii characters, the posts slug will be empty. due to:
`title = Regex.Replace(title, @"([^0-9a-z-])", string.Empty);`

also i make calling of string.Equals with `StringComparison.OrdinalIgnoreCase` which makes the intent of the code more clearly, i hope.
