### PR TITLE
Display images if the blog is in a subfolder of the website

### DIFF
--- a/Website/app_code/code/Post.cs
+++ b/Website/app_code/code/Post.cs
@@ -88,7 +88,8 @@ public class Post
         result = Regex.Replace(result, @"\[youtube:(.*?)\]", (Match m) => string.Format(video, m.Groups[1].Value));
 
         // Images replaced by CDN paths if they are located in the /posts/ folder
-        var cdn = ConfigurationManager.AppSettings.Get("blog:cdnUrl");
+        var cdnUrl = ConfigurationManager.AppSettings.Get("blog:cdnUrl");
+        var cdn = String.IsNullOrEmpty(cdnUrl) ? String.Format("/{0}", Blog.BlogPath) : cdnUrl;
         result = Regex.Replace(result, "<img.*?src=\"([^\"]+)\"", (Match m) =>
         {
             string src = m.Groups[1].Value;


### PR DESCRIPTION
This also avoid the problem with loading css, what is caused by setting your `<add key="blog:cdnUrl" value="subfolder"/>`. 
Image will show now, with this setting `<add key="blog:path" value="subfolder"/>` which is more natural.
