### PR TITLE
Now hashtag is removed from slug creation

### DIFF
--- a/Website/app_code/handlers/PostHandler.cs
+++ b/Website/app_code/handlers/PostHandler.cs
@@ -86,7 +86,7 @@ public class PostHandler : IHttpHandler
 
     public static string CreateSlug(string title)
     {
-        title = title.ToLowerInvariant().Replace(" ", "-");
+        title = title.ToLowerInvariant().Replace(" ", "-").Replace("#", "");
         title = RemoveDiacritics(title);
 
         if (Storage.GetAllPosts().Any(p => string.Equals(p.Slug, title, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
To prevent 404's hashtags are now removed when creating the slug.
Any hashtags in existing posts should manually be removed in the xml files.
Fixes #142 
