### PR TITLE
Actually fix xhtml parse issue

### DIFF
--- a/Website/scripts/admin.js
+++ b/Website/scripts/admin.js
@@ -14,7 +14,7 @@
         xHtmlDocument.importNode(htmlDocument.body, true);
         xhtmlBody.appendChild(htmlDocument.body.firstChild);
 
-        /<body.*?><div>(.*?)<\/div><\/body>/gim.exec(xHtmlDocument.documentElement.innerHTML);
+        /<body.*?><div>([\s\S]*?)<\/div><\/body>/i.exec(xHtmlDocument.documentElement.innerHTML);
         return RegExp.$1;
     }
 


### PR DESCRIPTION
Turns out the problem was actually that the html was multiline. Regardless of passing the m option, javascript doesn't properly support a single line regex.

Easy fix is to match \s\S (whitespace and not whitespace) rather than . so the match can break across lines.
