### PR TITLE
Fix pub date reset, Google+ sharing

### DIFF
--- a/Website/app_code/handlers/MetaWeblogHandler.cs
+++ b/Website/app_code/handlers/MetaWeblogHandler.cs
@@ -68,7 +68,7 @@ public class MetaWeblogHandler : XmlRpcService, IMetaWeblog
             match.Slug = post.Slug;
             match.Categories = post.Categories;
             match.IsPublished = publish;
-            match.PubDate = post.PubDate;
+
             Storage.Save(match);
         }
 

--- a/Website/themes/OffCanvas/_Layout.cshtml
+++ b/Website/themes/OffCanvas/_Layout.cshtml
@@ -42,7 +42,7 @@
     <div class="container">
         <div class="row row-offcanvas row-offcanvas-right">
             <header role="banner">
-                <span itemprop="name"><a href="~/" itemprop="url">@Blog.Title</a></span><br />
+                <span><a href="~/" itemprop="url">@Blog.Title</a></span><br />
                 <em>@Blog.Description</em>
             </header>
 

--- a/Website/themes/OneColumn/_Layout.cshtml
+++ b/Website/themes/OneColumn/_Layout.cshtml
@@ -41,7 +41,7 @@
 
     <div class="container">
         <header role="banner">
-            <span itemprop="name"><a href="~/" itemprop="url">@Blog.Title</a></span><br />
+            <span><a href="~/" itemprop="url">@Blog.Title</a></span><br />
             <em>@Blog.Description</em>
         </header>
 

--- a/Website/themes/TwoColumns/_Layout.cshtml
+++ b/Website/themes/TwoColumns/_Layout.cshtml
@@ -41,7 +41,7 @@
 
     <div class="container">
         <header role="banner">
-            <span itemprop="name"><a href="~/" itemprop="url">@Blog.Title</a></span><br />
+            <span><a href="~/" itemprop="url">@Blog.Title</a></span><br />
             <em>@Blog.Description</em>
         </header>
 


### PR DESCRIPTION
A couple small fixes here:
- Don't set PubDate on MetaWeblog Update call. If you set this, that makes the post pop to the top of the blog. This means if you went and edited an old post, it would suddenly pop to the top of the blog instead of staying in order where it was.
- Don't set itemprop="name" on the blog name. Google+ is stupid and picks this up as the post title when you go to share a link. Removing it allows the correct title to be used.