### PR TITLE
Chrome resizes images within table cell to match cell width

### DIFF
--- a/Website/themes/OffCanvas/site.css
+++ b/Website/themes/OffCanvas/site.css
@@ -23,6 +23,10 @@ img, video, iframe {
     max-width: 100%;
 }
 
+td img, video, iframe {
+    max-width: none;
+}
+
 a {
     color: #3277b3;
 }

--- a/Website/themes/OneColumn/site.css
+++ b/Website/themes/OneColumn/site.css
@@ -23,6 +23,10 @@ img, video, iframe {
     max-width: 100%;
 }
 
+td img, video, iframe {
+    max-width: none;
+}
+
 a {
     color: #3277b3;
 }

--- a/Website/themes/TwoColumns/site.css
+++ b/Website/themes/TwoColumns/site.css
@@ -23,6 +23,10 @@ img, video, iframe {
     max-width: 100%;
 }
 
+td img, video, iframe {
+    max-width: none;
+}
+
 a {
     color: #3277b3;
 }


### PR DESCRIPTION
Chrome resizes image widths within table cells to match cell width when
the max-width is 100%.  Internet Explorer does not.  Windows Live Writer
defaults table cells to 200px width.  If you resize the image inside the
table cell, with max-width 100% Chrome will set the image width to 200px
and image will be distorted.  Fix is to set max-width: none for images
within table cells.