### PR TITLE
added support for post teasers

### DIFF
--- a/Website/themes/OneColumn/Post.cshtml
+++ b/Website/themes/OneColumn/Post.cshtml
@@ -31,6 +31,24 @@
     {
         <div itemprop="articleBody">@Html.Raw(Model.Content)</div>
     }*@
+
+    @* Alternatively you can display post teasers in list view that are identified with <!--more--> markers*@
+    @*<div itemprop="articleBody">
+        @if (Blog.CurrentPost != null)
+        {
+            @Html.Raw(Blog.IsEditing ? Model.Content : Model.GetHtmlContent())
+        }
+        else if (Model.HasTeaser)
+        {
+            var teaser = string.Format("{0}<br><a href=\"{1}\" itemprop=\"url\">Read more</a>", 
+                Model.GetHtmlTeaser().Trim(), Model.Url);
+            @Html.Raw(teaser)
+        }
+        else
+        {
+            @Html.Raw(Model.GetHtmlContent())
+        }
+    </div>*@
     
     <div itemprop="articleBody">@Html.Raw(Blog.IsEditing ? Model.Content : Model.GetHtmlContent())</div>
 


### PR DESCRIPTION
Added an alternative way to provide post excerpts/teasers when listing posts. It's totally optional and works for posts that have a teaser marker: <!--more-->