### PR TITLE
re-enabled unpublished post preview feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Perfect for the blogger who wants to selfhost a blog.
  * You don't have to use WLW (but you should)
 * RSS and ATOM __feeds__
 * Schedule posts to be published on a future date
+* Get feedback on an unpublished post by sending a preview link 
 * __SEO__ optimized
  * Uses HTML 5 __microdata__ to add semantic meaning
  * Support for __robots.txt__ and __sitemap.xml__

--- a/Website/app_code/code/Blog.cs
+++ b/Website/app_code/code/Blog.cs
@@ -61,16 +61,33 @@ public static class Blog
     {
         get
         {
-            if (HttpContext.Current.Items["currentpost"] == null && !string.IsNullOrEmpty(CurrentSlug))
+            if (HttpContext.Current.Items["currentpost"] == null)
             {
-                var post = GetVisiblePosts().FirstOrDefault(p => p.Slug == CurrentSlug);
-
+                var post = FindCurrentPost();
                 if (post != null)
                     HttpContext.Current.Items["currentpost"] = post;
             }
 
             return HttpContext.Current.Items["currentpost"] as Post;
         }
+    }
+
+    private static Post FindCurrentPost()
+    {
+        if (string.IsNullOrEmpty(CurrentSlug))
+            return null;
+
+        var post = GetVisiblePosts().FirstOrDefault(p => p.Slug == CurrentSlug);
+        if (post == null)
+        {
+            var previewId = HttpContext.Current.Request.QueryString["key"];
+            if (!string.IsNullOrEmpty(previewId))
+            {
+                post = Storage.GetAllPosts().FirstOrDefault(p => p.Slug == CurrentSlug && p.ID.Equals(previewId, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        return post;
     }
 
     public static string GetNextPage()


### PR DESCRIPTION
Getting back the ability to get feedback before publishing a post by sending a link with '?key=postId' to an unauthenticated person.