### PR TITLE
better handling of categories that require Url encoding

### DIFF
--- a/Website/Web.config
+++ b/Website/Web.config
@@ -139,7 +139,7 @@
         </rule>
         <rule name="category" stopProcessing="true">
           <match url="^category/([^/]+)(/page/)?([\d]+)?" ignoreCase="true" />
-          <action type="Rewrite" url="?category={R:1}&amp;page={R:3}" />
+          <action type="Rewrite" url="?category={UrlEncode:{R:1}}&amp;page={R:3}" />
         </rule>
         <rule name="robots.txt" stopProcessing="true">
           <match url="robots.txt" />

--- a/Website/app_code/code/Blog.cs
+++ b/Website/app_code/code/Blog.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Web;
 using System.Web.Caching;
 using System.Web.Helpers;
@@ -38,7 +39,7 @@ public static class Blog
 
     public static string CurrentCategory
     {
-        get { return (HttpContext.Current.Request.QueryString["category"] ?? string.Empty).Trim().ToLowerInvariant(); }
+        get { return WebUtility.UrlDecode(HttpContext.Current.Request.QueryString["category"] ?? string.Empty).Trim().ToLowerInvariant(); }
     }
 
     public static bool IsNewPost
@@ -140,7 +141,7 @@ public static class Blog
     {
         var posts = GetVisiblePosts();
 
-        string category = HttpContext.Current.Request.QueryString["category"];
+        var category = CurrentCategory;
 
         if (!string.IsNullOrEmpty(category))
         {
@@ -184,7 +185,7 @@ public static class Blog
     public static string GetPagingUrl(int move)
     {
         string url = "/page/{0}/";
-        string category = HttpContext.Current.Request.QueryString["category"];
+        string category = CurrentCategory;
 
         if (!string.IsNullOrEmpty(category))
         {


### PR DESCRIPTION
On my blog I happen to have a category that has an ampersand character in its name and it was not handled properly by Url Rewrite module.
Also when filtering posts by a category we want to make sure we use a decoded string instead of a raw query string.