### PR TITLE
Removed unneeded css prefix for transition

### DIFF
--- a/Website/themes/OffCanvas/site.css
+++ b/Website/themes/OffCanvas/site.css
@@ -131,9 +131,6 @@ input[type], button, textarea {
     position: relative;
     max-height: 9999px;
     overflow: hidden;
-    -webkit-transition: height .5s ease-in-out;
-    -moz-transition: height .5s ease-in-out;
-    -o-transition: height .5s ease-in-out;
     transition: height .5s ease-in-out;
 }
 

--- a/Website/themes/OneColumn/site.css
+++ b/Website/themes/OneColumn/site.css
@@ -131,9 +131,6 @@ input[type], button, textarea {
     position: relative;
     max-height: 9999px;
     overflow: hidden;
-    -webkit-transition: height .5s ease-in-out;
-    -moz-transition: height .5s ease-in-out;
-    -o-transition: height .5s ease-in-out;
     transition: height .5s ease-in-out;
 }
 

--- a/Website/themes/TwoColumns/site.css
+++ b/Website/themes/TwoColumns/site.css
@@ -131,9 +131,6 @@ input[type], button, textarea {
     position: relative;
     max-height: 9999px;
     overflow: hidden;
-    -webkit-transition: height .5s ease-in-out;
-    -moz-transition: height .5s ease-in-out;
-    -o-transition: height .5s ease-in-out;
     transition: height .5s ease-in-out;
 }
 


### PR DESCRIPTION
When looking at [caniuse](http://caniuse.com/#search=transition) transition is widely supported.
they are not needed anymore, so I removed them.