### PR TITLE
Fixing MetaWeblog client fails on mt_excerpt being null

### DIFF
--- a/Website/app_code/handlers/MetaWeblogHandler.cs
+++ b/Website/app_code/handlers/MetaWeblogHandler.cs
@@ -118,7 +118,7 @@ public class MetaWeblogHandler : XmlRpcService, IMetaWeblog
             wp_slug = post.Slug,
             categories = post.Categories.ToArray(),
             postid = post.ID,
-            mt_excerpt = post.Excerpt
+            mt_excerpt = post.Excerpt ?? ""
         };
     }
 


### PR DESCRIPTION
MetaWeblog clients fail to open a blog post on mt_excerpt being null. E.g. Open Live Writer and MS Word do this.

Fix null > empty string.

Some clients (at least MS Word) appear to skip mt_excerpt leading it to be null instead of empty when publishing new blog posts.