### PR TITLE
Add blogPost scope to Excerpt selector

### DIFF
--- a/Website/scripts/admin.js
+++ b/Website/scripts/admin.js
@@ -179,7 +179,7 @@
     postId = $("[itemprop~='blogPost']").attr("data-id");
 
     txtTitle = $("[itemprop~='blogPost'] [itemprop~='name']");
-    txtExcerpt = $("[itemprop~='description']");
+    txtExcerpt = $("[itemprop~='blogPost'] [itemprop~='description']");
     txtContent = $("[itemprop~='articleBody']");
     txtMessage = $("#admin .alert");
     txtImage = $("#admin #txtImage");


### PR DESCRIPTION
When using the built-in editor, the selector for Excerpt is too broad:
`txtExcerpt = [itemprop~='description']");`

This finds all items on the page with this itemprop (even if not related to the blog post) and merges them together. 

Fix is just to scope the selector to the blogPost:
`txtExcerpt = $("[itemprop~='blogPost'] [itemprop~='description']");`